### PR TITLE
allow options object in install method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var pull = require('pull-level')
 var toStream = require('pull-stream-to-stream')
+var xtend = require('xtend')
 
 var liveStream = module.exports = function (db, opts) {
   var ts
@@ -14,14 +15,14 @@ var liveStream = module.exports = function (db, opts) {
   return ts = toStream(null, pull.read(db, opts))
 }
 
-module.exports.install = function (db) {
+module.exports.install = function (db, opts) {
   db.methods = db.methods || {}
   db.methods['liveStream'] =
   db.methods['createLiveStream'] = {type: 'readable'}
 
   db.liveStream =
   db.createLiveStream =
-    function (opts) {
-      return liveStream(db, opts)
+    function (_opts) {
+      return liveStream(db, xtend(opts, _opts))
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "url": "git://github.com/dominictarr/level-live-stream.git"
   },
   "dependencies": {
+    "pull-level": "~1.1.10",
     "pull-stream-to-stream": "~1.2.4",
-    "pull-level": "~1.1.10"
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "level-sublevel": ">=4.0.2",


### PR DESCRIPTION
This allows me to do the following on the server:

```js
var level = require('level')
var db = level('./foo')
var live = require('level-live-stream')
live.install(db, { valueEncoding: 'utf8' })
```

So I don't get the following crash on the server, just because the client didn't set proper `valueEncoding`. 
```
stream.js:94
      throw er; // Unhandled stream error in pipe.
            ^
EncodingError: Unexpected token k
```

This is only a problem in the case where `{ old: true }` is used. I need to get this options object down to `createReadStream(opts)` down the stack.

I could always use the main exported method but I think the `install()` method is very convenient. Also, I've seen you use `opts` and `_opts` pattern before so the change isn't that controversial :)
