### PR TITLE
Replace deprecated tail option

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var toStream = require('pull-stream-to-stream')
 var liveStream = module.exports = function (db, opts) {
   var ts
   opts = opts || {}
-  opts.tail = opts.tail !== false
+  opts.live = opts.live !== false
   if(opts.old === false)
     return toStream(null, pull.live(db, opts))
 

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ var i = 10
 var j = 10
 var k = 10
 
-LiveStream(db, {tail: true}).on('data', function (data) {
+LiveStream(db, {live: true}).on('data', function (data) {
   console.log(data)
   if(data.type === 'put')
     assert.equal(data.key, j--)


### PR DESCRIPTION
Hi @dominictarr, this is just a minor update to replace `tail` option in favor of `live`, so the module can stop warning about the deprecation.